### PR TITLE
[WIP]groups[メッセージエリア開設・部分テンプレート]を実装しました

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,6 +3,9 @@ class GroupsController < ApplicationController
   def index
   end
 
+  def group_messages_path(group)
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,6 @@
+class MessagesController < ApplicationController
+
+  def index
+  end
+
+end

--- a/app/views/devise/shared/_side_bar.html.haml
+++ b/app/views/devise/shared/_side_bar.html.haml
@@ -1,18 +1,20 @@
-.side-header
-  .side-header__box
-    %p.side-header__box__user-name
-      = current_user.name
-    %ul.side-header__box__menu
-      %li.side-header__box__menu__new-group
-        = link_to new_group_path do
-          = fa_icon 'pencil-square-o', class: 'icon'
-      %li.side-header__box__menu__edit-user
-        = link_to edit_user_path(current_user) do
-          = fa_icon 'cog', class: 'icon'
-.groups
-  - current_user.groups.each do |group|
-    .group
-      = link_to group_messages_path(group) do
-        %p.group__group-name
-          = group.name
-        %p.group__latest-message 最新のメッセージ
+.wrapper
+  .chat-side
+    .side-header
+      .side-header__box
+        %p.side-header__box__user-name
+          = current_user.name
+        %ul.side-header__box__menu
+          %li.side-header__box__menu__new-group
+            = link_to new_group_path do
+              = fa_icon 'pencil-square-o', class: 'icon'
+          %li.side-header__box__menu__edit-user
+            = link_to edit_user_path(current_user) do
+              = fa_icon 'cog', class: 'icon'
+    .groups
+      - current_user.groups.each do |group|
+        .group
+          = link_to group_messages_path(group) do
+            %p.group__group-name
+              = group.name
+            %p.group__latest-message 最新のメッセージ

--- a/app/views/groups/_chat_main.html.haml
+++ b/app/views/groups/_chat_main.html.haml
@@ -1,0 +1,31 @@
+.messages
+  .message{"data-message_id": "xxxx"}
+    .message__upper-info
+      %p.message__upper-info__talker メンバーの名前
+      %p.message__upper-info__date 2019/10/03(Thu) 19:05:09
+    %p.message__text メッセージのみメッセージのみメッセージのみメッセージのみメッセージのみメッセージのみ
+
+  .message{"data-message_id": "xxxx"}
+    .message__upper-info
+      %p.message__upper-info__talker メンバーの名前
+      %p.message__upper-info__date 2019/10/03(Thu) 19:05:09
+    %p.message__text
+    = image_tag 'http://d33f9sk7a6w0qk.cloudfront.net/ikinari_admin/wp-content/uploads/2014/08/topics01-11.png'
+
+  .message{"data-message_id": "xxxx"}
+    .message__upper-info
+      %p.message__upper-info__talker メンバーの名前
+      %p.message__upper-info__date 2019/10/03(Thu) 19:05:09
+    %p.message__text メッセージと画像メッセージと画像メッセージと画像メッセージと画像メッセージと画像メッセージと画像
+    = image_tag 'http://d33f9sk7a6w0qk.cloudfront.net/ikinari_admin/wp-content/uploads/2014/08/topics01-11.png'
+
+.form
+  %form#new_message.new_message{"accept-charset": "UTF-8", action: "#", enctype: "multipart/form-data", method: "post"}
+    %input{name: "utf8", type: "hidden", value: "✓"}/
+    %input{name: "authenticity_token", type: "hidden", value: "xxxx"}/
+    .input-box
+      %input#message_content.input-box__text{name: "message[content]", placeholder: "type a message", type: "text"}/
+      %label.input-box__image{for: "message_image"}
+        %i.fa.fa-image
+        %input#message_image.input-box__image__file{name: "message[image]", type: "file"}/
+    %input.submit-btn{"data-disable-with": "Send", name: "commit", type: "submit", value: "Send"}/

--- a/app/views/groups/_group_header.html.haml
+++ b/app/views/groups/_group_header.html.haml
@@ -1,0 +1,13 @@
+.main-header
+  .main-header__left-box
+
+    %h2.main-header__left-box__current-group{"data-group_id" => "xxxxx"}
+      現在見ているグループチャット
+
+    %ul.main-header__left-box__member-list
+      Member：
+      %li.main-header__left-box__member-list__member メンバーの名前
+      %li.main-header__left-box__member-list__member メンバーの名前
+
+  = link_to("/groups/1/edit") do
+    .main-header__edit-btn Edit

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,3 +1,4 @@
 = render 'devise/shared/side_bar'
 .chat-main
   = render 'groups/group_header'
+  = render 'groups/chat_main.html'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'messages/index'
+
   devise_for :users
   root to: "groups#index"
   resources :users, only: [:edit,:update]


### PR DESCRIPTION
#What
・メッセージエリア作成
・部分テンプレート化

#Why
・メッセージエリア作成
　＞メッセージコントローラを作成し、グループと隔離しました。
・部分テンプレート化
　＞上記の更新に伴い、メッセージエリア、および、グループヘッダーのテンプレート化を行いました。
　＞サイドバーよりグループごとのページへ遷移できるようになりました。